### PR TITLE
Addition of docker.presence.service file

### DIFF
--- a/ingress/docker.presence.service
+++ b/ingress/docker.presence.service
@@ -6,9 +6,9 @@ Requires=docker.service
 [Service]
 TimeoutStartSec=0
 Restart=always
-EnvironmentFile=/etc/aurora/topach.conf
+EnvironmentFile=/etc/aurora/aurora.conf
 ExecStartPre=-/usr/bin/docker login -u $USER -p $PASSWORD
-ExecStart=/usr/bin/docker run -p 6429:6429 --entrypoint ./presence generalfusion/presence:latest -p $PACH_IP -c versions -d $DATABASE_NAME -u $MONGO_URL
+ExecStart=/usr/bin/docker run -p $TOPACH_PORT:$TOPACH_PORT --entrypoint ./presence generalfusion/presence:latest -p $PACH_IP -c versions -d $DATABASE_NAME -u $MONGO_URL
 
 [Install]
 WantedBy=multi-user.target

--- a/ingress/docker.presence.service
+++ b/ingress/docker.presence.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Ingress Start for Presence Container
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+EnvironmentFile=/etc/aurora/topach.conf
+ExecStartPre=-/usr/bin/docker login -u $USER -p $PASSWORD
+ExecStart=/usr/bin/docker run -p 6429:6429 --entrypoint ./presence generalfusion/presence:latest -p $PACH_IP -c versions -d $DATABASE_NAME -u $MONGO_URL
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Uses common conf file edited by @jamesbak . Needs to be integrated into the shell script that uses systemd to create and run the presence service (like it does for the topach service)